### PR TITLE
QOL changes to improve tear gas feel

### DIFF
--- a/lua/entities/ent_jack_gmod_ezcsparticle.lua
+++ b/lua/entities/ent_jack_gmod_ezcsparticle.lua
@@ -153,9 +153,10 @@ elseif(CLIENT)then
 	function ENT:Initialize()
 		self.Col=Color(255,255,255)
 		self.Visible=true
-		self.Show=math.random(1,3)==2
+		self.Show=true
+		self.siz=1
 		timer.Simple(2,function()
-			if(IsValid(self))then self.Visible=math.random(1,5)==2 end
+			if(IsValid(self))then self.Visible=math.random(1,2)==2 end
 		end)
 		self.NextVisCheck=CurTime()+6
 		self.DebugShow=LocalPlayer().EZshowGasParticles
@@ -166,11 +167,15 @@ elseif(CLIENT)then
 			self:DrawModel()
 		end
 		local Time=CurTime()
+		if(self.NextVisCheck<Time)then
+			self.NextVisCheck=Time+1
+			self.Show=self.Visible and 1/FrameTime()>50
+		end
 		if(self.Show)then
-			local siz = 300
 			local SelfPos=self:GetPos()
 			render.SetMaterial(Mat)
-			render.DrawSprite(SelfPos,siz,siz,Color(self.Col.r,self.Col.g,self.Col.b,10))
+			render.DrawSprite(SelfPos,self.siz,self.siz,Color(self.Col.r,self.Col.g,self.Col.b,10))
+			self.siz=math.Clamp(self.siz+FrameTime()*200,0,500)
 		end
 	end
 end

--- a/lua/entities/ent_jack_gmod_ezgasparticle.lua
+++ b/lua/entities/ent_jack_gmod_ezgasparticle.lua
@@ -108,6 +108,7 @@ elseif(CLIENT)then
 		self.Col=Color(math.random(100,120),math.random(100,150),100)
 		self.Visible=true
 		self.Show=true
+		self.siz=1
 		timer.Simple(2,function()
 			if(IsValid(self))then self.Visible=math.random(1,5)==2 end
 		end)
@@ -126,9 +127,9 @@ elseif(CLIENT)then
 		end
 		if(self.Show)then
 			local SelfPos=self:GetPos()
-			local siz = 150
 			render.SetMaterial(Mat)
-			render.DrawSprite(SelfPos,siz,siz,Color(self.Col.r,self.Col.g,self.Col.b,30))
+			render.DrawSprite(SelfPos,self.siz,self.siz,Color(self.Col.r,self.Col.g,self.Col.b,30))
+			self.siz=math.Clamp(self.siz+FrameTime()*200,0,500)
 		end
 	end
 end

--- a/lua/jmod/cl_hud.lua
+++ b/lua/jmod/cl_hud.lua
@@ -160,7 +160,7 @@ hook.Add("RenderScreenspaceEffects","JMOD_SCREENSPACE",function()
 		blurMaterial:SetTexture("$BASETEXTURE", render.GetScreenEffectTexture())
 		blurMaterial:SetTexture("$DEPTHTEXTURE", render.GetResolvedFullFrameDepth())
 		
-		blurMaterial:SetFloat("$size", (CurVisionBlur*200)^.5)
+		blurMaterial:SetFloat("$size", (CurVisionBlur*40)^.5)
 		blurMaterial:SetFloat("$focus", 1)
 		blurMaterial:SetFloat("$focusradius", 1)
 		


### PR DESCRIPTION
Reduced tear gas blur strength to 20% (aware blur is modified exponentially) to improve feel
The new strength (at least by personal preference) feels a bit more realistic and less ugly but is strong enough the majority of the time to incapacitate players (players can navigate by large landmarks, but doorways and people are unnoticeable until a few feet away)

Reinstated the old version of fumigator gas sprite scaling as the new method starts off at full scale and the sprite model is small enough to appear ugly and awkward.

Applied the same method of fumigator gas sprite scaling to tear gas particles to fix the same problems. However, this also fixes a problem of the tear gas grenade spraying appearing awkward as invisible particles make the grenade appear buggy and non-functional.
The amount of visible tear gas particles is increased to half the total particles so the cloud feels present without blocking LOS


From semi-extensive testing, it appears that while prettier then bokeh blur and a bit easier on a gpu, pp/blurscreen is less effective at blinding players, so pp/bokehblur is the better option for tear gas.