### PR TITLE
Removed old force workshop IDs

### DIFF
--- a/lua/jmod/sv_init.lua
+++ b/lua/jmod/sv_init.lua
@@ -2,9 +2,6 @@ local force_workshop = CreateConVar("jmod_forceworkshop", 1, {FCVAR_ARCHIVE}, "F
 
 if force_workshop:GetBool() then
     resource.AddWorkshop("1919689921")
-    resource.AddWorkshop("1919703147")
-    resource.AddWorkshop("1919692947")
-    resource.AddWorkshop("1919694756")
 end
 
 local function JackaSpawnHook(ply)


### PR DESCRIPTION
These addons were removed, and the content was merged with the main addon, so they don't need to be marked for download.