### PR TITLE
Initial changes

### DIFF
--- a/lua/jmod/cl_gui.lua
+++ b/lua/jmod/cl_gui.lua
@@ -1081,6 +1081,11 @@ net.Receive("JMod_Inventory", function()
 	PlayerDisplay:SetPos(0, 0)
 	PlayerDisplay:SetSize(PDispBG:GetWide(), PDispBG:GetTall())
 	PlayerDisplay:SetModel(Ply:GetModel())
+	for k,v in pairs( Ply:GetBodyGroups() ) do
+		local ent = PlayerDisplay.Entity
+		local cur_bgid = Ply:GetBodygroup( v.id )
+		ent:SetBodygroup( v.id, cur_bgid )
+	end
 	PlayerDisplay:SetFOV(35)
 	PlayerDisplay:SetCursor("arrow")
 	local Ent = PlayerDisplay:GetEntity()

--- a/lua/jmod/sv_radio.lua
+++ b/lua/jmod/sv_radio.lua
@@ -279,13 +279,14 @@ end
 
 -- this is on the global table for third-party use
 function JMod.AddNewRadioOutpost(teamID)
-	table.insert(JMod.EZ_RADIO_STATIONS, CreateRadioStation(teamID))
-
-	for k, ply in pairs(player.GetAll()) do
-		if (tostring(ply:Team()) == teamID) or tostring(ply:AccountID() == teamID) then
-			ply:PrintMessage(HUD_PRINTTALK, "Your team has gained a radio outpost.")
-		end
-	end
+    table.insert(JMod.EZ_RADIO_STATIONS, CreateRadioStation(teamID))
+    for k, ply in pairs(player.GetAll()) do
+        if (tostring(ply:Team()) == teamID) or tostring(ply:AccountID() == teamID) and ply:Team() ~= 1001 then
+            ply:PrintMessage(HUD_PRINTTALK, "Team " .. team.GetName(teamID) .. " has gained a radio outpost.")
+        elseif ply:Team() == 1001 then
+            ply:PrintMessage(HUD_PRINTTALK, "Player " .. ply:Nick() .. " has gained a radio outpost.")
+        end
+    end
 end
 
 -- this is also on the global table for third-party use
@@ -302,10 +303,12 @@ function JMod.RemoveRadioOutPost(teamID)
 	end
 
 	for k, ply in pairs(player.GetAll()) do
-		if (tostring(ply:Team()) == teamID) or tostring(ply:AccountID() == teamID) then
-			ply:PrintMessage(HUD_PRINTTALK, "Your team has lost a radio outpost.")
-		end
-	end
+        if (tostring(ply:Team()) == teamID) or tostring(ply:AccountID() == teamID) and ply:Team() ~= 1001 then
+            ply:PrintMessage(HUD_PRINTTALK, "Team " .. team.GetName(teamID) .. " has lost a radio outpost.")
+        elseif ply:Team() == 1001 then
+            ply:PrintMessage(HUD_PRINTTALK, "Player " .. ply:Nick() .. " has lost a radio outpost.")
+        end
+    end
 end
 
 concommand.Add("jmod_debug_addoutpost", function(ply, cmd, args)


### PR DESCRIPTION
-EZ Inventory now shows the player's current bodygroups. 
-Outpost adding/removing now prints different messages based on whether the player's current team is 1001(Unassigned), or a custom team.