### PR TITLE
Fabricator recipe rebalance

### DIFF
--- a/lua/jmod/sh_config.lua
+++ b/lua/jmod/sh_config.lua
@@ -118,7 +118,7 @@ function JMod.InitGlobalConfig(forceNew)
 					description = "1 box of advparts used for crafting and upgrading.",
 					category = "Resources",
 					results = {
-						{"ent_jack_gmod_ezadvparts", 1, 20}
+						{"ent_jack_gmod_ezadvparts", 1, 15}
 					}
 				},
 				["precision parts"] = {
@@ -1065,7 +1065,7 @@ function JMod.InitGlobalConfig(forceNew)
 					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 30,
 					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 20,
 					[JMod.EZ_RESOURCE_TYPES.GLASS] = 10,
-					[JMod.EZ_RESOURCE_TYPES.COPPER] = 20,
+					[JMod.EZ_RESOURCE_TYPES.COPPER] = 30,
 					[JMod.EZ_RESOURCE_TYPES.WOOD] = 10,
 					[JMod.EZ_RESOURCE_TYPES.RUBBER] = 10
 				},
@@ -1082,7 +1082,7 @@ function JMod.InitGlobalConfig(forceNew)
 					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 90,
 					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 60,
 					[JMod.EZ_RESOURCE_TYPES.GLASS] = 30,
-					[JMod.EZ_RESOURCE_TYPES.COPPER] = 60,
+					[JMod.EZ_RESOURCE_TYPES.COPPER] = 90,
 					[JMod.EZ_RESOURCE_TYPES.WOOD] = 30,
 					[JMod.EZ_RESOURCE_TYPES.RUBBER] = 30
 				},
@@ -1093,7 +1093,7 @@ function JMod.InitGlobalConfig(forceNew)
 			["EZ Precision Parts, x100"] = {
 				results = "ent_jack_gmod_ezprecparts",
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 50,
+					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 100,
 					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 20,
 					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 20,
 					[JMod.EZ_RESOURCE_TYPES.SILVER] = 30,
@@ -1108,7 +1108,7 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezprecparts", 1, 10}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 5,
+					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 10,
 					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 2,
 					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 2,
 					[JMod.EZ_RESOURCE_TYPES.SILVER] = 3,
@@ -1123,7 +1123,7 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezadvparts", 1, 50}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 50,
+					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 100,
 					[JMod.EZ_RESOURCE_TYPES.GOLD] = 40,
 					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 20,
 					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 40
@@ -1137,7 +1137,7 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezadvparts", 1, 5}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 5,
+					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 10,
 					[JMod.EZ_RESOURCE_TYPES.GOLD] = 4,
 					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 2,
 					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 4

--- a/lua/jmod/sh_config.lua
+++ b/lua/jmod/sh_config.lua
@@ -118,7 +118,7 @@ function JMod.InitGlobalConfig(forceNew)
 					description = "1 box of advparts used for crafting and upgrading.",
 					category = "Resources",
 					results = {
-						{"ent_jack_gmod_ezadvparts", 1, 5}
+						{"ent_jack_gmod_ezadvparts", 1, 20}
 					}
 				},
 				["precision parts"] = {
@@ -1061,11 +1061,11 @@ function JMod.InitGlobalConfig(forceNew)
 			["EZ Basic Parts, x100"] = {
 				results = "ent_jack_gmod_ezbasicparts",
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.STEEL] = 100,
-					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 50,
-					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 30,
-					[JMod.EZ_RESOURCE_TYPES.GLASS] = 20,
-					[JMod.EZ_RESOURCE_TYPES.COPPER] = 10,
+					[JMod.EZ_RESOURCE_TYPES.STEEL] = 50,
+					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 30,
+					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 20,
+					[JMod.EZ_RESOURCE_TYPES.GLASS] = 10,
+					[JMod.EZ_RESOURCE_TYPES.COPPER] = 20,
 					[JMod.EZ_RESOURCE_TYPES.WOOD] = 10,
 					[JMod.EZ_RESOURCE_TYPES.RUBBER] = 10
 				},
@@ -1078,11 +1078,11 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezbasicparts", 3}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.STEEL] = 300,
-					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 150,
-					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 90,
-					[JMod.EZ_RESOURCE_TYPES.GLASS] = 60,
-					[JMod.EZ_RESOURCE_TYPES.COPPER] = 30,
+					[JMod.EZ_RESOURCE_TYPES.STEEL] = 150,
+					[JMod.EZ_RESOURCE_TYPES.ALUMINUM] = 90,
+					[JMod.EZ_RESOURCE_TYPES.PLASTIC] = 60,
+					[JMod.EZ_RESOURCE_TYPES.GLASS] = 30,
+					[JMod.EZ_RESOURCE_TYPES.COPPER] = 60,
 					[JMod.EZ_RESOURCE_TYPES.WOOD] = 30,
 					[JMod.EZ_RESOURCE_TYPES.RUBBER] = 30
 				},
@@ -1093,11 +1093,11 @@ function JMod.InitGlobalConfig(forceNew)
 			["EZ Precision Parts, x100"] = {
 				results = "ent_jack_gmod_ezprecparts",
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 300,
-					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 100,
-					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 100,
-					[JMod.EZ_RESOURCE_TYPES.SILVER] = 50,
-					[JMod.EZ_RESOURCE_TYPES.CERAMIC] = 50
+					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 50,
+					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 20,
+					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 20,
+					[JMod.EZ_RESOURCE_TYPES.SILVER] = 30,
+					[JMod.EZ_RESOURCE_TYPES.CERAMIC] = 20
 				},
 				category = "Resources",
 				craftingType = "fabricator",
@@ -1108,11 +1108,11 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezprecparts", 1, 10}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 30,
-					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 10,
-					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 10,
-					[JMod.EZ_RESOURCE_TYPES.SILVER] = 5,
-					[JMod.EZ_RESOURCE_TYPES.CERAMIC] = 5
+					[JMod.EZ_RESOURCE_TYPES.BASICPARTS] = 5,
+					[JMod.EZ_RESOURCE_TYPES.TUNGSTEN] = 2,
+					[JMod.EZ_RESOURCE_TYPES.TITANIUM] = 2,
+					[JMod.EZ_RESOURCE_TYPES.SILVER] = 3,
+					[JMod.EZ_RESOURCE_TYPES.CERAMIC] = 2
 				},
 				category = "Resources",
 				craftingType = "fabricator",
@@ -1123,10 +1123,10 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezadvparts", 1, 50}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 150,
-					[JMod.EZ_RESOURCE_TYPES.GOLD] = 50,
-					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 25,
-					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 25
+					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 50,
+					[JMod.EZ_RESOURCE_TYPES.GOLD] = 40,
+					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 20,
+					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 40
 				},
 				category = "Resources",
 				craftingType = "fabricator",
@@ -1137,10 +1137,10 @@ function JMod.InitGlobalConfig(forceNew)
 					{"ent_jack_gmod_ezadvparts", 1, 5}
 				},
 				craftingReqs = {
-					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 15,
-					[JMod.EZ_RESOURCE_TYPES.GOLD] = 5,
-					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 3,
-					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 3
+					[JMod.EZ_RESOURCE_TYPES.PRECISIONPARTS] = 5,
+					[JMod.EZ_RESOURCE_TYPES.GOLD] = 4,
+					[JMod.EZ_RESOURCE_TYPES.DIAMOND] = 2,
+					[JMod.EZ_RESOURCE_TYPES.PLATINUM] = 4
 				},
 				category = "Resources",
 				craftingType = "fabricator",


### PR DESCRIPTION
After some playtesting has been done, I realized that nobody is ever going to really bother using the fabricator in it's current state and with what is available currently in Econ 2 Phase 1. It is only really useful in an incredibly end-game state, where 90% of people playing this seriously aren't going to reach. 

I want to make it more useful, and actually have people make use of it. (and the model that boots spent so much care making)

So,
The general idea that I am aiming to be accomplished with this PR is turning the Fabricator into a tool that people can invest a lot of orders and time into in order to give themselves the advantage over others in the long run, while still being useful when you aren't in a position to have 5 drills around the map under your control.
What's been changed:
All recipe costs have been lowered substantially, making it to where you don't need to be 100% generating what resources you can in order to have the recipes be worthwhile making.
The advparts order has been increased from 5 to 15, making it to where you don't **have** to get the fabricator in order to be able to afford advparts recipes/upgrades in a reasonable timeframe. 

Once we have radio orders actually balanced in Phase 2, these recipes can definitely be reconsidered since there won't necessarily be the radio to compete with in terms of what is worthwhile to use.

thanks for coming to my ted talk