### PR TITLE
Gasmask flashbang protection

### DIFF
--- a/lua/entities/ent_jack_gmod_ezflashbang.lua
+++ b/lua/entities/ent_jack_gmod_ezflashbang.lua
@@ -32,9 +32,13 @@ if SERVER then
 		self:EmitSound("snd_jack_fragsplodeclose.wav", 90, 140)
 		local plooie = EffectData()
 		plooie:SetOrigin(SelfPos)
-		util.Effect("eff_jack_gmod_flashbang", plooie, true, true)
-		util.ScreenShake(SelfPos, 20, 20, .2, 1000)
-
+		for k,ply in pairs(player.GetHumans()) do 
+			if ply.EZarmor and not (ply.EZarmor.effects.eyePro) then 
+				util.Effect("eff_jack_gmod_flashbang", plooie, true, true)
+				util.ScreenShake(SelfPos, 20, 20, .2, 1000)
+			else return nil
+			end
+		end
 		for k, v in pairs(ents.FindInSphere(SelfPos, 200)) do
 			if v:IsNPC() then
 				v.EZNPCincapacitate = Time + math.Rand(3, 5)

--- a/lua/jmod/sh_armor.lua
+++ b/lua/jmod/sh_armor.lua
@@ -167,6 +167,9 @@ JMod.ArmorTable = {
 		pos = Vector(0, .1, 0),
 		ang = Angle(100, 180, 90),
 		wgt = 5,
+		eff = {
+			eyePro = true
+		},
 		mskmat = "mats_jack_gmod_sprites/vignette_gray.png",
 		sndlop = "snds_jack_gmod/mask_breathe.wav",
 		ent = "ent_jack_gmod_ezarmor_gasmask",

--- a/lua/jmod/sh_armor.lua
+++ b/lua/jmod/sh_armor.lua
@@ -908,6 +908,9 @@ JMod.ArmorTable = {
 		plymdl = "models/bloocobalt/splinter cell/chemsuit_cod.mdl", -- https://steamcommunity.com/sharedfiles/filedetails/?id=243665786&searchtext=splinter+cell+blacklist
 		mskmat = "mats_jack_gmod_sprites/vignette_gray.png",
 		sndlop = "snds_jack_gmod/mask_breathe.wav",
+		eff = {
+			eyePro = true
+		},
 		wgt = 15,
 		dur = 8,
 		ent = "ent_jack_gmod_ezarmor_hazmat"


### PR DESCRIPTION
Players can now equip the EZ Gas Mask to protect not only against chemicals but flashbangs as well.