### PR TITLE
Darma blackhole MaxAge edit

### DIFF
--- a/lua/entities/ent_jack_gmod_ezblackhole.lua
+++ b/lua/entities/ent_jack_gmod_ezblackhole.lua
@@ -52,7 +52,7 @@ function ENT:SUCC(Time, Phys, Age, Pos, MaxRange)
 				self:Rape(obj)
 			else
 				-- inverse square law bitchins
-				local PullStrength = ((1 - Dist / MaxRange) ^ 2) * ((JMod.Config and JMod.Config.Machines.Blackhole.GravityStrength) or 1)
+				local PullStrength = ((1 - Dist / MaxRange) ^ 2) * JMod.Config.Machines.Blackhole.GravityStrength
 				local Mass = ObjPhys:GetMass()
 				local ApplyForce, Mul = true, 1
 
@@ -137,6 +137,7 @@ if SERVER then
 		self.Entity:SetMoveType(MOVETYPE_VPHYSICS)
 		self.Entity:SetSolid(SOLID_VPHYSICS)
 		self.Entity:DrawShadow(true)
+		self.HawkingRadiationAge = JMod.Config.Machines.Blackhole.MaxAge - math.sqrt(JMod.Config.Machines.Blackhole.MaxAge) + 1
 
 		---
 		timer.Simple(.01, function()
@@ -168,11 +169,11 @@ if SERVER then
 		local MaxRange = Age * 150
 		self:SUCC(Time, Phys, Age, Pos, MaxRange)
 
-		if Age > 90 then
-			self:EmitHawkingRadiation(Age - 90)
+		if Age > self.HawkingRadiationAge then
+			self:EmitHawkingRadiation(Age - self.HawkingRadiationAge)
 		end
 
-		if Age >= 100 then
+		if Age >= JMod.Config.Machines.Blackhole.MaxAge then
 			self:Die()
 
 			return

--- a/lua/jmod/sh_config.lua
+++ b/lua/jmod/sh_config.lua
@@ -14,7 +14,7 @@ function JMod.InitGlobalConfig(forceNew, configToApply)
 		Note = "radio packages must have all lower-case names, see http://wiki.garrysmod.com/page/Enums/IN for key numbers",
 		Info = {
 			Author = "Jackarunda & Friends",
-			Version = 42.6,
+			Version = 42.61,
 		},
 		General = {
 			Hints = true,
@@ -55,6 +55,7 @@ function JMod.InitGlobalConfig(forceNew, configToApply)
 			Blackhole = {
 				GeneratorChargeSpeed = 1,
 				EvaporateSpeed = 1,
+				MaxAge = 100,
 				GravityStrength = 1,
 				Whitelist = {"func_physbox", "func_breakable"},
 				Blacklist = {"func_", "_dynamic"},


### PR DESCRIPTION
Adds MaxAge config entry for blackhole, setting the age at which the blackhole ent dies
Adds HawkingRadiationAge for calculating when the hawking radiation effect starts
Removes unnecessary checks protecting GravityStrength

The current formula for hawking radiation threshold is  **y = x - sqrt{x} + 1**

Demonstration of blackhole with MaxAge 10
https://github.com/Jackarunda/gmod/assets/62033006/5ab50865-bb09-4668-9346-92e17f3a6dfa

