### PR TITLE
Fix talker is a nil value

### DIFF
--- a/lua/jmod/sv_init.lua
+++ b/lua/jmod/sv_init.lua
@@ -859,6 +859,7 @@ function JMod.EZ_Remote_Trigger(ply)
 end
 
 hook.Add("PlayerCanSeePlayersChat", "JMOD_PLAYERSEECHAT", function(txt, teamOnly, listener, talker)
+	if not IsValid(talker) then return end
 	if talker.EZarmor and talker.EZarmor.effects.teamComms then return JMod.PlayersCanComm(listener, talker) end
 end)
 


### PR DESCRIPTION
The speaker parameter does not have to be a valid Player object which happens when console messages are displayed for example.

https://wiki.facepunch.com/gmod/GM:PlayerCanSeePlayersChat